### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 5s
       retries: 5
   kafka:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     networks:
       - kafka-net
     container_name: kafka


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)